### PR TITLE
Nzylstra/fix send card

### DIFF
--- a/hangouts_chat.py
+++ b/hangouts_chat.py
@@ -15,10 +15,12 @@ from markdownconverter import hangoutschat_markdown_converter
 
 log = logging.getLogger('errbot.backends.hangoutschat')
 
+
 def removeprefix(source: str, prefix: str):
     if source.startswith(prefix):
         return source[len(prefix):]
     return source
+
 
 class RoomsNotSupportedError(RoomError):
     def __init__(self, message=None):
@@ -124,6 +126,7 @@ class HangoutsChatRoom(Room):
     """
     Represents a 'Space' in Google-Hangouts-Chat terminology
     """
+
     def __init__(self, space_id, chat_api):
         super().__init__()
         self.space_id = space_id
@@ -271,7 +274,6 @@ class GoogleHangoutsChatBackend(ErrBot):
             msg.to = self.bot_identifier
         self.callback_message(msg)
 
-
     def _split_message(self, text, maximum_message_length=GoogleHangoutsChatAPI.max_message_length):
         '''
         Splits a given string up into multiple strings all of length less than some maximum size
@@ -290,7 +292,6 @@ class GoogleHangoutsChatBackend(ErrBot):
 
         messages.append(current_message)
         return messages
-
 
     def send_message(self, message):
         super(GoogleHangoutsChatBackend, self).send_message(message)
@@ -317,16 +318,16 @@ class GoogleHangoutsChatBackend(ErrBot):
                 for mention in mentions:
                     message_payload['annotations'].append(
                         {
-                        "type":"USER_MENTION",
-                        "startIndex":mention['start'],
-                        "length":mention['length'],
-                        "userMention": {
-                            "user": {
-                                "name": mention['user_id'],
-                                "displayName":mention['display_name'],
-                                "type":"HUMAN"
-                            },
-                            "type":"ADD"
+                            "type": "USER_MENTION",
+                            "startIndex": mention['start'],
+                            "length": mention['length'],
+                            "userMention": {
+                                "user": {
+                                    "name": mention['user_id'],
+                                    "displayName": mention['display_name'],
+                                    "type": "HUMAN"
+                                },
+                                "type": "ADD"
                             }
                         }
                     )


### PR DESCRIPTION
`send_card` was not previously working because its function signature does not match the caller's signature.

- All plugins in errbot call `send_card` using [this function](https://github.com/errbotio/errbot/blob/master/errbot/botplugin.py#L654)
- That function calls the loaded backend's `send_card` with the function signature of `send_card(card)`
- Our current backend expects `send_card` to be called with the signature of `send_card(cards, space_id, thread_id=None)`
- So our current backend errors on `send_card` every time because it does not receive `space_id`

This PR updates our backend to match the expected backend `send_card` function signature.  See some of the [built-in backends as examples](https://github.com/errbotio/errbot/blob/af358ffb7284ee6191f16f182732e57bc3e7f4b3/errbot/backends/slack.py#L864).

 