### PR TITLE
Add messageReplyOption to support new threading

### DIFF
--- a/hangouts_chat.py
+++ b/hangouts_chat.py
@@ -142,7 +142,7 @@ class GoogleHangoutsChatAPI:
             return self._request(url, body=json.dumps(body), method='POST')
         else:
             return self._request(url, body=json.dumps(body), method='POST',
-                                 query_string='threadKey={}'.format(thread_key))
+                                 query_string='threadKey={}&messageReplyOption={}'.format(thread_key, 'REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD'))
 
 
 class HangoutsChatRoom(Room):


### PR DESCRIPTION
Add messageReplyOption querystring parameter set to REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD to support new threading while maintaining support for topic based rooms